### PR TITLE
Promote to prod environment

### DIFF
--- a/components/nodejs-hxrklclp/overlays/prod/deployment-patch.yaml
+++ b/components/nodejs-hxrklclp/overlays/prod/deployment-patch.yaml
@@ -12,5 +12,5 @@ spec:
   template: 
     spec:
       containers:
-      - image: quay.io/redhat-appstudio/dance-bootstrap-app:latest
+      - image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/nodejs-hxrklclp:bb2c6a3aad7f6c394c55b494905973019a57c098@sha256:ad9ed646d7db371a0c9f53b9715c04c9eff410e67e961c83911554088c22f975
         name: container-image  


### PR DESCRIPTION
This PR promotes the application to the prod environment with image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/nodejs-hxrklclp:bb2c6a3aad7f6c394c55b494905973019a57c098@sha256:ad9ed646d7db371a0c9f53b9715c04c9eff410e67e961c83911554088c22f975